### PR TITLE
Make tutorial even if tutorial_state is none

### DIFF
--- a/pokeminer/worker.py
+++ b/pokeminer/worker.py
@@ -280,6 +280,11 @@ class Worker:
         except (KeyError, TypeError):
             pass
 
+        # Sometimes we don't get tutorial_state in new accounts
+        # Line 264 can be [] too and we forget about this if.
+        if tutorial_state is None:
+            tutorial_state = []
+
         await random_sleep(.7, 1.2)
 
         # request 2: download_remote_config_version
@@ -295,7 +300,7 @@ class Worker:
         if (config.COMPLETE_TUTORIAL and
                 tutorial_state is not None and
                 not all(x in tutorial_state for x in (0, 1, 3, 4, 7))):
-            self.logger.warning('Starting tutorial')
+            self.logger.warning('{} is starting tutorial'.format(self.username))
             await self.complete_tutorial(tutorial_state)
         else:
             # request 4: get_player_profile


### PR DESCRIPTION
The new accounts do not seem to have the `tutorial_state` inside the `player_data`.
```json
{"player_data": { 
    "max_pokemon_storage": 250, 
    "buddy_pokemon": {}, 
    "equipped_badge": {}, 
    "username": "islastres", 
    "max_item_storage": 350, 
    "remaining_codename_claims": 2, 
    "creation_timestamp_ms": 1485378832681, 
    "currencies": [
        {"name": "POKECOIN"}, 
        {"amount": 604, "name": "STARDUST"}], 
        "daily_bonus": {}, 
        "contact_settings": {}
    }, 
    "success": true
}
```
In the old accounts that I have, the `player_data` like this:
```json
{"player_data": {
    "buddy_pokemon": {},
    "equipped_badge": {},
    "creation_timestamp_ms": 1481545472141,
    "avatar": {
        "hair": 3,
        "shirt": 2,
        "eyes": 3,
        "shoes": 1,
        "pants": 2,
        "backpack": 3
    }, 
    "daily_bonus": {},
    "max_pokemon_storage": 250,
    "username": "XXXX", 
    "max_item_storage": 350, 
    "remaining_codename_claims": 1, 
    "currencies": [
        {"name": "POKECOIN"}, 
        {"amount": 19148, "name": "STARDUST"}
    ], 
    "contact_settings": {}, 
    "tutorial_state": [0, 1, 3, 4, 7]}, 
    "success": true
}
```