### PR TITLE
Fix not moving issue on first bootstrap / simple winwdows bashes

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -50,7 +50,7 @@ SIMULTANEOUS_SIMULATION = 10
 # Immediately select workers whose speed are below (SPEED_UNIT)p/h instead of
 # continuing to try to find the worker with the lowest speed.
 # May increase clustering if you have a high density of workers.
-#GOOD_ENOUGH = 4
+GOOD_ENOUGH = 4
 
 # Seconds to sleep after failing to find an eligible worker before trying again.
 SEARCH_SLEEP = 2.5

--- a/scan.bat
+++ b/scan.bat
@@ -1,0 +1,1 @@
+python scan.py

--- a/web.bat
+++ b/web.bat
@@ -1,0 +1,1 @@
+python web.py


### PR DESCRIPTION
The default commented value, makes the workers not moving on the bootstrap.
I made 2 simple bashes for scan and web on windows.
Thanks, 