### PR TITLE
Add CP and Level to db, webhook, and frontend

### DIFF
--- a/monocle/db.py
+++ b/monocle/db.py
@@ -225,6 +225,8 @@ class Sighting(Base):
     sta_iv = Column(TINY_TYPE)
     move_1 = Column(SmallInteger)
     move_2 = Column(SmallInteger)
+    cp = Column(SmallInteger)
+    level = Column(SmallInteger)
 
     __table_args__ = (
         UniqueConstraint(
@@ -253,6 +255,8 @@ class Mystery(Base):
     sta_iv = Column(TINY_TYPE)
     move_1 = Column(SmallInteger)
     move_2 = Column(SmallInteger)
+    cp = Column(SmallInteger)
+    level = Column(SmallInteger)
 
     __table_args__ = (
         UniqueConstraint(
@@ -354,7 +358,9 @@ def add_sighting(session, pokemon):
         def_iv=pokemon.get('individual_defense'),
         sta_iv=pokemon.get('individual_stamina'),
         move_1=pokemon.get('move_1'),
-        move_2=pokemon.get('move_2')
+        move_2=pokemon.get('move_2'),
+        cp=pokemon.get('cp'),
+        level=pokemon.get('level')
     )
     session.add(obj)
     SIGHTING_CACHE.add(pokemon)
@@ -453,7 +459,9 @@ def add_mystery(session, pokemon):
         def_iv=pokemon.get('individual_defense'),
         sta_iv=pokemon.get('individual_stamina'),
         move_1=pokemon.get('move_1'),
-        move_2=pokemon.get('move_2')
+        move_2=pokemon.get('move_2'),
+        cp=pokemon.get('cp'),
+        level=pokemon.get('level')
     )
     session.add(obj)
     MYSTERY_CACHE.add(pokemon)

--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -786,6 +786,8 @@ class Notifier:
             data['message']['height'] = pokemon['height']
             data['message']['weight'] = pokemon['weight']
             data['message']['gender'] = pokemon['gender']
+            data['message']['cp'] = pokemon['cp']
+            data['message']['pokemon_level'] = pokemon['level']
         except KeyError:
             pass
 

--- a/monocle/static/js/main.js
+++ b/monocle/static/js/main.js
@@ -84,7 +84,8 @@ function getPopupContent (item) {
         content += 'Disappears in: ' + expires_at + '<br>';
         content += 'Move 1: ' + item.move1 + ' ( ' + item.damage1 + ' dps )<br>';
         content += 'Move 2: ' + item.move2 + ' ( ' + item.damage2 + ' dps )<br>';
-        content += 'IV: ' + item.atk + ' atk, ' + item.def + ' def, ' + item.sta + ' sta<br>'
+        content += 'IV: ' + item.atk + ' atk, ' + item.def + ' def, ' + item.sta + ' sta<br>';
+        content += 'CP: ' + item.cp + ' | Lvl: ' + item.level + '<br>';
     } else {
         content += '<br>Disappears in: ' + expires_at + '<br>';
     }

--- a/monocle/utils.py
+++ b/monocle/utils.py
@@ -325,3 +325,12 @@ def randomize_point(point, amount=0.0003, randomize=uniform):
         randomize(lat - amount, lat + amount),
         randomize(lon - amount, lon + amount)
     )
+
+
+def calc_pokemon_level(cp_multiplier):
+    if cp_multiplier < 0.734:
+        pokemon_level = (58.35178527 * cp_multiplier * cp_multiplier - 2.838007664 * cp_multiplier + 0.8539209906)
+    else:
+        pokemon_level = 171.0112688 * cp_multiplier - 95.20425243
+    pokemon_level = int((round(pokemon_level) * 2) / 2)
+    return pokemon_level

--- a/monocle/web_utils.py
+++ b/monocle/web_utils.py
@@ -105,6 +105,8 @@ def sighting_to_marker(pokemon, names=POKEMON, moves=MOVES, damage=DAMAGE):
         marker['move2'] = moves[move2]
         marker['damage1'] = damage[move1]
         marker['damage2'] = damage[move2]
+        marker['cp'] = pokemon.cp
+        marker['level'] = pokemon.level
     return marker
 
 

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -12,7 +12,7 @@ from cyrandom import choice, randint, uniform
 from pogeo import get_distance
 
 from .db import FORT_CACHE, MYSTERY_CACHE, SIGHTING_CACHE
-from .utils import round_coords, load_pickle, get_device_info, get_start_coords, Units, randomize_point
+from .utils import round_coords, load_pickle, get_device_info, get_start_coords, Units, randomize_point, calc_pokemon_level
 from .shared import get_logger, LOOP, SessionManager, run_threaded, ACCOUNTS
 from . import altitudes, avatar, bounds, db_proc, spawns, sanitized as conf
 
@@ -991,6 +991,8 @@ class Worker:
             pokemon['height'] = pdata.height_m
             pokemon['weight'] = pdata.weight_kg
             pokemon['gender'] = pdata.pokemon_display.gender
+            pokemon['cp'] = pdata.cp
+            pokemon['level'] = calc_pokemon_level(pdata.cp_multiplier)
         except KeyError:
             self.log.error('Missing encounter response.')
         self.error_code = '!'

--- a/web_sanic.py
+++ b/web_sanic.py
@@ -97,7 +97,7 @@ async def pokemon_data(request, _time=time):
     last_id = request.args.get('last_id', 0)
     async with app.pool.acquire() as conn:
         results = await conn.fetch('''
-            SELECT id, pokemon_id, expire_timestamp, lat, lon, atk_iv, def_iv, sta_iv, move_1, move_2
+            SELECT id, pokemon_id, expire_timestamp, lat, lon, atk_iv, def_iv, sta_iv, move_1, move_2, cp, level
             FROM sightings
             WHERE expire_timestamp > {} AND id > {}
         '''.format(_time(), last_id))
@@ -177,6 +177,8 @@ def sighting_to_marker(pokemon, names=POKEMON, moves=MOVES, damage=DAMAGE, trash
         marker['move2'] = moves[move2]
         marker['damage1'] = damage[move1]
         marker['damage2'] = damage[move2]
+        marker['cp'] = pokemon['cp']
+        marker['level'] = pokemon['level']
     return marker
 
 


### PR DESCRIPTION
CP and Pokemon Level are as useful as IV in that if you level 30 accounts they are nice to report.  Since we are reporting IV, it makes sense to report CP and Level as well.  Credit to Asner who's code helped me add CP.