### PR TITLE
Fix bug in ENCOUNTER = 'some'

### DIFF
--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -798,14 +798,17 @@ class Worker:
                             self.log.warning('{} during encounter', e.__class__.__name__)
 
                 if notify_conf and self.notifier.eligible(normalized):
-                    if encounter_conf and 'move_1' not in normalized:
-                        try:
-                            await self.encounter(normalized, pokemon.spawn_point_id)
-                        except CancelledError:
-                            db_proc.add(normalized)
-                            raise
-                        except Exception as e:
-                            self.log.warning('{} during encounter', e.__class__.__name__)
+                    if (encounter_conf == 'all'
+                            or (encounter_conf == 'some'
+                            and normalized['pokemon_id'] in conf.ENCOUNTER_IDS)):
+                        if encounter_conf and 'move_1' not in normalized:
+                            try:
+                                await self.encounter(normalized, pokemon.spawn_point_id)
+                            except CancelledError:
+                                db_proc.add(normalized)
+                                raise
+                            except Exception as e:
+                                self.log.warning('{} during encounter', e.__class__.__name__)
                     LOOP.create_task(self.notifier.notify(normalized, map_objects.time_of_day))
                 db_proc.add(normalized)
 


### PR DESCRIPTION
-Included ENCOUNTER = ‘some’ flag when NOTIFY = True and
ALWAYS_NOTIFY_IDS is populated.
-Without this check, everything in ALWAYS_NOTIFY_IDS will be encountered.
-This will allow you to use ENCOUNTER_IDS = { 201 } to just encounter Unown, but still allow you to send notifications in the ALWAYS_NOTIFY_IDS list. 
-Tested using encounter to show gender and display results in PokeAlarm. Used Pidgey and Ekans to test, encountering Pidgey in the ENCOUNTER_IDS = {} to show gender, and Pidgey and Ekans in the ALWAYS_NOTIFY_IDS = {} list. Result would show Pidgey with gender and Ekans with ?.
-Also tested using my own live fork which now displays Unown form correctly.