### PR TITLE
Fix Pokéstop spinning.

### DIFF
--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -211,7 +211,11 @@ class Worker:
 
             player_data = get_player.player_data
             tutorial_state = player_data.tutorial_state
-            self.item_capacity = player_data.max_item_storage
+
+            # API can return 0 as capacity.
+            if player_data.max_item_storage != 0:
+                self.item_capacity = player_data.max_item_storage
+
             if 'created' not in self.account:
                 self.account['created'] = player_data.creation_timestamp_ms / 1000
         except (KeyError, TypeError, AttributeError):


### PR DESCRIPTION
The API can return `0` as `max_item_storage`, mostly seen when accounts haven't completed the tutorial yet. This overwrites the original default of `350` and makes the pokéstop spinning check on [worker.py#L823](https://github.com/Noctem/Monocle/blob/develop/monocle/worker.py#L823) fail every time.

No pokéstop spinning = accounts stay at level one = captchas.